### PR TITLE
fix: Update for changes to discordgo WebhookEdit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/Moonlington/harmonia
 
 go 1.18
 
-require github.com/bwmarrin/discordgo v0.25.0
+require github.com/bwmarrin/discordgo v0.26.1
 
 require (
 	github.com/gorilla/websocket v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bwmarrin/discordgo v0.25.0 h1:NXhdfHRNxtwso6FPdzW2i3uBvvU7UIQTghmV2T4nqAs=
-github.com/bwmarrin/discordgo v0.25.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
+github.com/bwmarrin/discordgo v0.26.1 h1:AIrM+g3cl+iYBr4yBxCBp9tD9jR3K7upEjl0d89FRkE=
+github.com/bwmarrin/discordgo v0.26.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b h1:7mWr3k41Qtv8XlltBkDkl8LoP3mpSgBW8BUoxtEdbXg=

--- a/harmonia.go
+++ b/harmonia.go
@@ -206,7 +206,7 @@ func (h *Harmonia) DeferResponse(i *Invocation) error {
 // EditResponse edits an already sent response.
 func (h *Harmonia) EditResponse(i *Invocation, content string) (*InteractionMessage, error) {
 	m, err := h.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-		Content: content,
+		Content: &content,
 	})
 	return h.interactionMessageFromMessage(m, i.Interaction), err
 }
@@ -215,8 +215,8 @@ func (h *Harmonia) EditResponse(i *Invocation, content string) (*InteractionMess
 func (h *Harmonia) EditResponseWithComponents(i *Invocation, content string, components [][]discordgo.MessageComponent) (*InteractionMessage, error) {
 	comp := ParseComponentMatrix(components)
 	m, err := h.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-		Content:    content,
-		Components: comp,
+		Content:    &content,
+		Components: &comp,
 	})
 	return h.interactionMessageFromMessage(m, i.Interaction), err
 }
@@ -262,7 +262,7 @@ func (h *Harmonia) FollowupComplex(i *Invocation, params *discordgo.WebhookParam
 // EditFollowup allows you to edit a follow-up message.
 func (h *Harmonia) EditFollowup(f *InteractionMessage, content string) (*InteractionMessage, error) {
 	m, err := h.FollowupMessageEdit(f.Interaction, f.ID, &discordgo.WebhookEdit{
-		Content: content,
+		Content: &content,
 	})
 	return h.interactionMessageFromMessage(m, f.Interaction), err
 }
@@ -271,8 +271,8 @@ func (h *Harmonia) EditFollowup(f *InteractionMessage, content string) (*Interac
 func (h *Harmonia) EditFollowupWithComponents(f *InteractionMessage, content string, components [][]discordgo.MessageComponent) (*InteractionMessage, error) {
 	comp := ParseComponentMatrix(components)
 	m, err := h.FollowupMessageEdit(f.Interaction, f.ID, &discordgo.WebhookEdit{
-		Content:    content,
-		Components: comp,
+		Content:    &content,
+		Components: &comp,
 	})
 	return h.interactionMessageFromMessage(m, f.Interaction), err
 }


### PR DESCRIPTION
discordgo changed the WebhookEdit struct to contain pointers instead of struct literals. This change updates harmonia to use pointers as well.